### PR TITLE
Added support version Laravel 10.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.history
 # IntelliJ project files
 .idea
 *.iml

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,9 @@
     "sphinx",
     "sphinxsearch",
     "laravel",
-    "laravel 5"
+    "laravel 5",
+    "laravel 9",
+    "laravel 10"
   ],
   "homepage": "https://github.com/biblioonline/sphinxsearch-l5",
   "license": "MIT",
@@ -13,11 +15,15 @@
     {
       "name": "biblioonline",
       "email": "danik0072@gmail.com"
+    },
+    {
+      "name": "ggmanuilov",
+      "email": "ggmanuilov@gmail.com"
     }
   ],
   "require": {
     "php": ">=5.3.0",
-    "illuminate/support": "~5.0",
+    "illuminate/support": "~5.0|~9|~10",
     "gigablah/sphinxphp": "2.0.8"
   },
   "autoload": {

--- a/readme.md
+++ b/readme.md
@@ -96,6 +96,24 @@ $results = $sphinx->search('my query', 'index_name')
 	->get();
 ```
 
+Query with bind Shinx index on Model.
+In the file `config/sphinxsearch.php`
+```php
+return array (
+	'host'    => '127.0.0.1',
+	'port'    => 9312,
+	'indexes' => array (
+		'index_name' => array ( 'table' => 'my_keywords_table', 'column' => 'id', 'modelname' => App\Category::class ),
+	)
+);
+```
+Eloquent query.
+```php
+$results = $sphinx->search('my query', 'index_name')->get();
+// $results is an array of App\Category objects.
+```
+
+
 Query with match and sort type specified.
 ```php
 $result = $sphinx->search('my query', 'index_name')

--- a/src/sngrl/SphinxSearch/SphinxSearch.php
+++ b/src/sngrl/SphinxSearch/SphinxSearch.php
@@ -218,11 +218,11 @@ class SphinxSearch
                     } else if (isset($config['modelname'])) {
                         if ($this->_eager_loads) {
                             $result = call_user_func_array($config['modelname'] . "::whereIn",
-                                array($config['column'], $matchids))->orderByRaw(\DB::raw("FIELD($primaryKey, $idString)"))
+                                array($config['column'], $matchids))->orderByRaw("FIELD($primaryKey, $idString)")
                                 ->with($this->_eager_loads)->get();
                         } else {
                             $result = call_user_func_array($config['modelname'] . "::whereIn",
-                                array($config['column'], $matchids))->orderByRaw(\DB::raw("FIELD($primaryKey, $idString)"))
+                                array($config['column'], $matchids))->orderByRaw("FIELD($primaryKey, $idString)")
                                 ->get();
                         }
                     } else {


### PR DESCRIPTION
Previously, the orderByRaw method expected `\Illuminate\Database\Query\Expression' but since version Laravel 10 it expects 'string'.

Details here https://laravel.com/docs/10.x/upgrade#database-expressions